### PR TITLE
fix: fix empty parameter type for dictionary function

### DIFF
--- a/source/cli/build.ts
+++ b/source/cli/build.ts
@@ -51,7 +51,7 @@ function generateDictionaryType(obj: any, indent = 0): string {
       const paramCount = value.length
 
       if (paramCount === 0)
-        type = 'string'
+        type = '() => string'
       else if (paramCount === 1)
         // Plural functions always take a single number parameter
         type = '(value: number) => string'


### PR DESCRIPTION
Make function localization with no arguments to be type of function, not string.

### Example
```yaml
year:
  !js
  () => new Date().getFullYear()
```

### Actual
types.ts contains `year: string`

### Expected
types.ts contains `year: () => string`