### PR TITLE
fix: fix function type errors

### DIFF
--- a/features/build.feature
+++ b/features/build.feature
@@ -132,5 +132,5 @@ Feature: Build
     When I run `npx intl build -p ./test-js`
     Then the file `test-js/types.ts` contains:
       """
-      formatSingle: (value: number | string) => string
+      formatSingle: (value: any) => string
       """

--- a/source/cli/build.ts
+++ b/source/cli/build.ts
@@ -60,7 +60,7 @@ function generateDictionaryType(obj: any, indent = 0): string {
           type = '(value: number) => string'
         else
           // !js functions with single argument can take number or string
-          type = '(value: number | string) => string'
+          type = '(value: any) => string'
       } else {
         const params = Array(paramCount).fill('any').join(', ')
 


### PR DESCRIPTION
# Problem
Using `string | number` argument type leads to type checking errors, if function body uses methods incompatible with one of them.

## Example

```js
// generated built.js
...
"success": (name) => {
  return `${name.charAt(0).toUpperCase() + name.slice(1)} refreshed 🎉`
}
...
```

```ts
// generated types.ts
...
success: (value: number | string) => string
...
```

#### Error
```
Property 'charAt' does not exist on type 'string | number'.
  Property 'charAt' does not exist on type 'number'.ts(2339)
```

# Solution
Use `any` type