### PR TITLE
feat: create languages in mounts

### DIFF
--- a/features/create.feature
+++ b/features/create.feature
@@ -11,3 +11,26 @@ Feature: Create command
       example:
         hello: Hola mundo
       """
+
+  Scenario: Add locale to mount
+    When I run `npx intl hola`
+    And I run `npx intl mount foo src/foo/intl`
+    Then the file `src/lib/intl/context.yaml` contains:
+      """
+      mounts:
+        foo: ../../foo/intl
+      """
+    When I run `npx intl set foo/hello "Hello world"`
+    Then the file `src/foo/intl/en-US.yaml` contains:
+      """
+      native: English
+      locale: en-US
+      hello: Hello world
+      """
+    When I run `npx intl create es-ES`
+    Then the file `src/foo/intl/es-ES.yaml` contains:
+      """
+      native: Español
+      locale: es-ES
+      hello: Hola mundo
+      """

--- a/source/cli/CreateCommand.ts
+++ b/source/cli/CreateCommand.ts
@@ -112,25 +112,6 @@ export class CreateCommand {
       logger.log(`Found ${Object.keys(savedContexts).length} saved contexts for enhanced translation`)
     }
 
-    if (entries.length === 0) {
-      // Create minimal file with just native name
-      const initialContent = {
-        native: nativeName,
-        locale: targetLang,
-      }
-
-      const yamlContent = yaml.dump(initialContent, {
-        lineWidth: -1,
-        quotingType: '"',
-        forceQuotes: false,
-      })
-
-      fs.writeFileSync(targetFile, yamlContent)
-      require('./build').build(i18nPath)
-      logger.log(`✅ Created ${targetFile} with native name: ${nativeName}`)
-      return
-    }
-
     // Create system prompt for translations
     const systemPrompt = `You are a professional translator for an internationalization system. You will receive text in ANY locale and must translate it to the specified target locale.
 
@@ -174,45 +155,47 @@ Target language: ${targetLang}
 
 Return ONLY the translation as a string.`
 
-    // Translate entries in batches of 10
+    // Translate entries in batches of 10 (or create a minimal file if there is nothing to translate)
     const translatedData: any = {
       native: nativeName,
       locale: targetLang
     }
 
-    const batchSize = 10
-    for (let i = 0; i < entries.length; i += batchSize) {
-      const batch = entries.slice(i, i + batchSize)
-      const batchKeys = batch.map(e => e.key)
-      const batchValues = batch.map(e => e.value)
-      const batchContexts = batch.map(e => savedContexts[e.key]?.input)
+    if (entries.length > 0) {
+      const batchSize = 10
+      for (let i = 0; i < entries.length; i += batchSize) {
+        const batch = entries.slice(i, i + batchSize)
+        const batchKeys = batch.map(e => e.key)
+        const batchValues = batch.map(e => e.value)
+        const batchContexts = batch.map(e => savedContexts[e.key]?.input)
 
-      logger.log(`Translating batch ${Math.floor(i / batchSize) + 1}: ${batchKeys.join(', ')}`)
+        logger.log(`Translating batch ${Math.floor(i / batchSize) + 1}: ${batchKeys.join(', ')}`)
 
-      try {
-        const batchTranslations = await this.translateBatch(
-          batchValues,
-          batchContexts,
-          targetLang,
-          systemPrompt
-        )
+        try {
+          const batchTranslations = await this.translateBatch(
+            batchValues,
+            batchContexts,
+            targetLang,
+            systemPrompt
+          )
 
-        // Apply translations to the data structure
-        for (let j = 0; j < batch.length; j++) {
-          const entry = batch[j]
-          const translation = batchTranslations[j]
-          if (translation) {
-            this.setNestedValue(translatedData, entry.key, translation)
-          } else {
-            // Fallback to original value
+          // Apply translations to the data structure
+          for (let j = 0; j < batch.length; j++) {
+            const entry = batch[j]
+            const translation = batchTranslations[j]
+            if (translation) {
+              this.setNestedValue(translatedData, entry.key, translation)
+            } else {
+              // Fallback to original value
+              this.setNestedValue(translatedData, entry.key, entry.value)
+            }
+          }
+        } catch (error) {
+          logger.error(`Failed to translate batch: ${error}`)
+          // Fallback to original values for the entire batch
+          for (const entry of batch) {
             this.setNestedValue(translatedData, entry.key, entry.value)
           }
-        }
-      } catch (error) {
-        logger.error(`Failed to translate batch: ${error}`)
-        // Fallback to original values for the entire batch
-        for (const entry of batch) {
-          this.setNestedValue(translatedData, entry.key, entry.value)
         }
       }
     }
@@ -229,8 +212,9 @@ Return ONLY the translation as a string.`
     // Create files in all mounted partitions as well
     const allMounts = this.translationService.contextManagerInstance.getAllMounts(i18nPath)
     for (const [mountName, mountPath] of Object.entries(allMounts)) {
-      const partitionI18nDir = `${i18nPath}/${mountPath}`
-      const partitionTargetFile = `${partitionI18nDir}/${targetLang}.yaml`
+      // mountPath is stored relative to the main i18n directory
+      const partitionI18nDir = path.resolve(i18nDir, mountPath)
+      const partitionTargetFile = path.join(partitionI18nDir, `${targetLang}.yaml`)
 
       // Create directory if it doesn't exist
       if (!fs.existsSync(partitionI18nDir)) {

--- a/source/cli/MountCommand.ts
+++ b/source/cli/MountCommand.ts
@@ -6,9 +6,11 @@
  */
 
 import { existsSync, mkdirSync, writeFileSync, readFileSync, readdirSync } from 'fs'
-import { resolve, join, dirname, relative } from 'path'
+import { resolve, join, relative } from 'path'
 import { build } from './build'
 import { ContextFileManager } from './context'
+import { load as yamlLoad, dump as yamlDump } from 'js-yaml'
+import { getNativeLanguageName } from './bcp47'
 
 export class MountCommand {
   private log(message: string): void {
@@ -58,17 +60,39 @@ export class MountCommand {
       this.error(`No locale files found in main directory: ${i18nDir}`)
     }
 
-    // Create empty YAML files for each locale (without native key)
+    // Create locale YAML files for the mount (with native/locale header)
     for (const localeFile of localeFiles) {
       const localeName = localeFile.replace('.yaml', '')
       const mountFilePath = join(absoluteMountPath, localeFile)
 
       // Only create if it doesn't exist
       if (!existsSync(mountFilePath)) {
-        // Create empty YAML file (just a comment header)
-        const initialDict = `# ${localeName} dictionary\n# Add your translations here\n`
+        // Copy native/locale header from the main dictionary if possible,
+        // otherwise fall back to BCP47 native name detection.
+        const mainLocalePath = join(i18nDir, localeFile)
+        let native = getNativeLanguageName(localeName)
+        let locale = localeName
 
-        writeFileSync(mountFilePath, initialDict)
+        try {
+          const mainContent = readFileSync(mainLocalePath, 'utf8')
+          const mainData = yamlLoad(mainContent) as any
+          if (mainData && typeof mainData === 'object') {
+            if (typeof mainData.native === 'string')
+              native = mainData.native
+            if (typeof mainData.locale === 'string')
+              locale = mainData.locale
+          }
+        } catch {
+          // ignore, fallback to inferred native/locale above
+        }
+
+        const initialYaml = yamlDump({ native, locale }, {
+          lineWidth: -1,
+          quotingType: '"',
+          forceQuotes: false,
+        })
+
+        writeFileSync(mountFilePath, initialYaml)
         this.log(`✓ Created empty ${localeName} dictionary: ${mountFilePath}`)
       }
     }

--- a/source/cli/TranslationService.ts
+++ b/source/cli/TranslationService.ts
@@ -128,9 +128,8 @@ export class TranslationService {
 
       // Ensure all target locales are included, using original value for missing ones
       for (const locale of allLocales) {
-        if (!(locale in translations)) {
+        if (!(locale in translations))
           translations[locale] = content
-        }
       }
 
       return translations

--- a/source/cli/build.ts
+++ b/source/cli/build.ts
@@ -5,10 +5,11 @@
  * @author copilot
  */
 
-import { writeFileSync, readdirSync } from 'fs'
+import { writeFileSync, readdirSync, existsSync, readFileSync } from 'fs'
 import { resolve } from 'path'
 import { load } from './load'
 import { hasPartitions } from './partition'
+import { load as yamlLoad } from 'js-yaml'
 
 /**
  * Generate TypeScript type definitions for the dictionary structure
@@ -140,13 +141,22 @@ export function build(i18nPath = './src/lib/intl/'): void {
 
   const i18nDir = resolve(process.cwd(), i18nPath)
 
-  // Check if this is a partition directory or main directory
-  const fs = require('fs')
+  // Check if this is a mount (partition) directory.
+  // Mounts have their own context.yaml created by `intl mount` and should not
+  // include native/locale headers in built output dictionaries.
   const path = require('path')
-  const isPartition = i18nDir !== resolve(process.cwd(), './src/lib/intl/') &&
-    fs.existsSync(path.join(path.dirname(i18nDir), 'built.js'))
+  const contextPath = resolve(i18nDir, 'context.yaml')
+  let stripMetaKeys = false
+  if (existsSync(contextPath)) {
+    try {
+      const ctx = yamlLoad(readFileSync(contextPath, 'utf8')) as any
+      stripMetaKeys = Boolean(ctx && typeof ctx === 'object' && typeof ctx.context === 'string' && ctx.context.startsWith('Mount '))
+    } catch {
+      stripMetaKeys = false
+    }
+  }
 
-  if (!isPartition) {
+  if (!stripMetaKeys) {
     // Build all partitions when building from main directory
     // First check for mounted partitions from context.yaml
     const contextManager = new (require('./context').ContextFileManager)()
@@ -154,7 +164,7 @@ export function build(i18nPath = './src/lib/intl/'): void {
 
     for (const [mountName, mountPath] of Object.entries(allMounts)) {
       const partitionI18nDir = path.resolve(i18nDir, mountPath)
-      if (fs.existsSync(partitionI18nDir)) {
+      if (existsSync(partitionI18nDir)) {
         console.log(`Building mount: ${mountName}`)
         build(path.relative(process.cwd(), partitionI18nDir))
       }
@@ -162,7 +172,7 @@ export function build(i18nPath = './src/lib/intl/'): void {
 
     // Also check for subdirectory partitions (legacy support)
     if (hasPartitions(i18nPath)) {
-      const entries = fs.readdirSync(i18nDir, { withFileTypes: true })
+      const entries = readdirSync(i18nDir, { withFileTypes: true })
 
       for (const entry of entries) {
         if (entry.isDirectory()) {
@@ -170,7 +180,7 @@ export function build(i18nPath = './src/lib/intl/'): void {
           const partitionPath = path.join(i18nPath, entry.name)
 
           // Check if this directory contains YAML files (is a partition)
-          const partitionEntries = fs.readdirSync(partitionDir)
+          const partitionEntries = readdirSync(partitionDir)
           if (partitionEntries.some((file: string) => file.match(/^[a-z]{2}(-[A-Z]{2})?\.yaml$/))) {
             console.log(`Building mount: ${entry.name}`)
             build(partitionPath)
@@ -203,6 +213,16 @@ export function build(i18nPath = './src/lib/intl/'): void {
     } catch (error) {
       console.error(`❌ Failed to process ${lang}.yaml:`, error)
       throw error
+    }
+  }
+
+  if (stripMetaKeys) {
+    for (const lang of Object.keys(dictionaries)) {
+      const dict = dictionaries[lang]
+      if (dict && typeof dict === 'object') {
+        const { native: _native, locale: _locale, ...rest } = dict
+        dictionaries[lang] = rest
+      }
     }
   }
 


### PR DESCRIPTION
## Issue

When adding new language with `reate {lang}` command, nothing added to mounts

## Expected

Running `create {lang}` command creates corresponding translations in mounts