### PR TITLE
feat: add `intl import <name> <dir>` adopts an existing mount

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,9 +142,10 @@ Mounts allow you to organize translations into separate directories anywhere in 
 ```bash
 npx intl mount foo ./any/path # creates foo mount with empty dictionaries for all locales
 npx intl set foo/bar.baz "Hello mount" # set key in mount 'foo'
+npx intl import bar ./vendor/bar-intl # adopt an existing dictionary dir as a mount
 ```
 
-Mounts are created with the same languages as the root dictionary but start empty (no `native` key).
+Mounts are created with the same languages as the root dictionary but start empty (no `native` key). Use `import` instead to adopt a **populated** dictionary directory and reconcile its locales to the root.
 
 Mounts are useful for:
 
@@ -233,6 +234,12 @@ npx intl mount <mount> <dir>
 ```
 
 Create a dictionary mount at the specified path with empty dictionaries for all languages in the root directory. Mounts can be addressed with `mount/key` key syntax. Example: `npx intl set mount/key "value" "context"`.
+
+```bash
+npx intl import <name> <dir> [--js]
+```
+
+Adopt an existing dictionary directory (must contain `context.yaml`) as a mount and reconcile its locales to the root: drop languages the root lacks, generate languages it has but the mount lacks (translating the imported `inputs` with the root's context and genders), leave shared locales untouched. Errors if `<name>` is already a mount.
 
 ```bash
 npx intl unmount <mount>

--- a/features/import.feature
+++ b/features/import.feature
@@ -1,0 +1,83 @@
+Feature: Import command
+
+  Scenario: Error when directory has no context.yaml
+    When I run `npx intl hola`
+    And I run `npx intl import ext ./external`
+    Then the output contains:
+      """
+      ❌
+      """
+
+  Scenario: Error when mount name already registered
+    When I run `npx intl hola`
+    Given a file `external/context.yaml`:
+      """
+      context: External
+      inputs: {}
+      """
+    When I run `npx intl import ext ./external`
+    And I run `npx intl import ext ./external`
+    Then the output contains:
+      """
+      Mount 'ext' already exists
+      """
+
+  Scenario: Import an external mount and reconcile its locales
+    When I run `npx intl hola`
+    And I run `npx intl create ru-RU`
+    Given a file `external/context.yaml`:
+      """
+      context: External greeting module
+      inputs:
+        greeting:
+          hi:
+            input: Hello
+            context: a friendly greeting
+      """
+    And a file `external/en-US.yaml`:
+      """
+      greeting:
+        hi: Hello
+      """
+    And a file `external/fr-FR.yaml`:
+      """
+      greeting:
+        hi: Bonjour
+      """
+    When I run `npx intl import ext ./external`
+    Then the file `src/lib/intl/context.yaml` contains:
+      """
+      ext: ../../../external
+      """
+    And the file `external/fr-FR.yaml` does not exist
+    And the file `external/ru-RU.yaml` contains:
+      """
+      greeting:
+        hi:
+      """
+    And the file `external/ru-RU.yaml` does not contain:
+      """
+      hi: Hello
+      """
+    And the file `external/ru-RU.yaml` does not contain:
+      """
+      native:
+      """
+    And the file `external/en-US.yaml` contains:
+      """
+      hi: Hello
+      """
+    And the file `external/built.js` contains:
+      """
+      "en-US": {
+          "greeting": {
+            "hi": "Hello"
+          }
+        }
+      """
+    And the file `external/built.js` contains:
+      """
+      "ru-RU": {
+          "greeting": {
+            "hi":
+      """

--- a/features/steps/Terminal.ts
+++ b/features/steps/Terminal.ts
@@ -1,9 +1,9 @@
 import { execSync } from 'child_process'
-import { mkdtempSync, readdirSync, readFileSync, writeFileSync } from 'fs'
+import { existsSync, mkdirSync, mkdtempSync, readdirSync, readFileSync, writeFileSync } from 'fs'
 import { strict as assert } from 'node:assert'
 import { tmpdir } from 'os'
-import { join } from 'path'
-import { When, Then, Before } from '@cucumber/cucumber'
+import { dirname, join } from 'path'
+import { When, Then, Given, Before } from '@cucumber/cucumber'
 import dotenv from 'dotenv'
 import * as YAML from 'js-yaml'
 
@@ -15,6 +15,23 @@ let cwd: string = ''
 Before(function() {
   // Create a new temp directory for each scenario
   cwd = mkdtempSync(join(tmpdir(), 'intl-test-'))
+})
+
+Given(/a file `([^`]+)`:/, function(rel: string, content: string) {
+  const path = join(cwd, rel)
+
+  mkdirSync(dirname(path), { recursive: true })
+  writeFileSync(path, content)
+})
+
+Then(/the file `([^`]+)` does not exist/, function(rel: string) {
+  assert(!existsSync(join(cwd, rel)), `${rel} should not exist`)
+})
+
+Then(/the file `([^`]+)` does not contain:/, function(rel: string, unexpected: string) {
+  const content = readFileSync(join(cwd, rel), 'utf8')
+
+  assert(!content.includes(unexpected.trim()), `${rel} unexpectedly includes:\n${unexpected.trim()}`)
 })
 
 When(/I run `([^`]+)`/, function(command: string) {

--- a/skills/svintl/SKILL.md
+++ b/skills/svintl/SKILL.md
@@ -28,7 +28,8 @@ npx intl move old.key new.key               # rename key/branch
 npx intl del key.path                       # delete key/branch
 npx intl create es                          # new locale (BCP 47 tag, auto-translates)
 npx intl destroy es                         # delete locale
-npx intl mount foo ./any/path               # create mount
+npx intl mount foo ./any/path               # create empty mount
+npx intl import foo ./any/path              # adopt existing dict dir as mount, reconcile locales
 npx intl unmount foo                        # remove mount (keeps files)
 npx intl context "Project description"      # set project-wide translation guidance
 npx intl context --clear                    # clear project context
@@ -102,6 +103,8 @@ npx intl set "admin/dashboard.title" "Admin Dashboard"
 ```
 
 Mount keys use `{mount}/` prefix in CLI commands.
+
+`mount` scaffolds an empty mount; `import` adopts a populated dir (with its own `context.yaml`) and reconciles its locales to the root — drops languages the root lacks, generates ones it lacks (translating the imported `inputs`), leaves shared locales untouched.
 
 ## Import Pattern
 

--- a/source/cli/CreateCommand.ts
+++ b/source/cli/CreateCommand.ts
@@ -328,6 +328,53 @@ Return ONLY the translation as a string.`
     require('./build').build(i18nPath)
   }
 
+  /**
+   * Batch-translate a flat list of entries (with per-key context) into a nested
+   * object of translated keys only — no reserved native/locale/dir keys.
+   * Reuses the same OpenAI batch logic as `execute`. Empty input → empty object.
+   * Shared with ImportCommand to avoid duplicating the translation pipeline.
+   */
+  async translateEntries(
+    entries: Array<{ key: string; value: string; context?: string }>,
+    targetLang: string,
+    projectContext?: string,
+    genderInstructions?: string | null
+  ): Promise<Record<string, any>> {
+    const result: any = {}
+
+    if (entries.length === 0)
+      return result
+
+    const systemPrompt = `You are a professional translator for an internationalization system. You will receive text in ANY locale and must translate it to the specified target locale.
+
+${this.translationService.getCommonTranslationPromptBody()}
+
+Target language: ${targetLang}
+
+Return ONLY the translation as a string.`
+    const systemPromptWithGender = genderInstructions ? `${systemPrompt}\n\n${genderInstructions}` : systemPrompt
+
+    const batchSize = 10
+    for (let i = 0; i < entries.length; i += batchSize) {
+      const batch = entries.slice(i, i + batchSize)
+      const batchValues = batch.map(e => e.value)
+      const batchContexts = batch.map(e => e.context)
+
+      const batchTranslations = await this.translateBatch(
+        batchValues,
+        batchContexts,
+        targetLang,
+        systemPromptWithGender,
+        projectContext
+      )
+
+      for (let j = 0; j < batch.length; j++)
+        this.setNestedValue(result, batch[j].key, batchTranslations[j] ?? batch[j].value)
+    }
+
+    return result
+  }
+
   private extractEntries(obj: any, prefix = ''): Array<{ key: string; value: string }> {
     const entries: Array<{ key: string; value: string }> = []
 

--- a/source/cli/ImportCommand.ts
+++ b/source/cli/ImportCommand.ts
@@ -1,0 +1,93 @@
+/**
+ * CLI command for importing an existing dictionary directory as a mount.
+ * Registers the directory under the root `mounts:`, then reconciles its locale
+ * set to the root project: drops mount-only locales, generates root-only ones
+ * (by translating the imported `context.yaml` inputs), leaves the intersection
+ * untouched. The imported `context.yaml` is never modified.
+ */
+
+import { existsSync, mkdirSync, readdirSync, readFileSync, unlinkSync, writeFileSync } from 'fs'
+import { join, relative, resolve } from 'path'
+import { dump as yamlDump } from 'js-yaml'
+import { build } from './build'
+import { ContextFileManager } from './context'
+import { CreateCommand } from './CreateCommand'
+import { TranslationService } from './TranslationService'
+
+const LOCALE_FILE = /^[a-z]{2}(-[A-Z]{2})?\.yaml$/
+
+export class ImportCommand {
+  private contextManager = new ContextFileManager()
+  private translationService = new TranslationService()
+  private createCommand = new CreateCommand()
+
+  private error(message: string): never {
+    console.error(`❌ ${message}`)
+    process.exit(1)
+  }
+
+  async execute(name: string, dir: string, useJavaScript = false, i18nPath = './src/lib/intl/'): Promise<void> {
+    const i18nDir = resolve(process.cwd(), i18nPath)
+    const absImportPath = resolve(process.cwd(), dir)
+    const relativeImportPath = relative(i18nDir, absImportPath)
+
+    if (!existsSync(i18nDir))
+      this.error(`Main intl directory does not exist: ${i18nDir}. Run 'npx intl hola' first.`)
+
+    if (!existsSync(absImportPath) || !existsSync(join(absImportPath, 'context.yaml')))
+      this.error(`Import directory must exist and contain a context.yaml: ${absImportPath}`)
+
+    if (this.contextManager.getMountPath(i18nPath, name))
+      this.error(`Mount '${name}' already exists`)
+
+    // Create an index file from the mount template only when absent.
+    const indexFileName = useJavaScript ? 'index.js' : 'index.ts'
+    const indexFile = join(absImportPath, indexFileName)
+    if (!existsSync(indexFile)) {
+      const templateFile = useJavaScript ? 'mount.js' : 'mount.ts'
+      const templatePath = join(resolve(__dirname, '..'), 'index', templateFile)
+
+      if (!existsSync(templatePath))
+        this.error(`Template file not found: ${templatePath}`)
+
+      writeFileSync(indexFile, readFileSync(templatePath, 'utf8'))
+    }
+
+    // Register the mount before reconciling so it participates in `build`.
+    this.contextManager.setMountPath(i18nPath, name, relativeImportPath)
+
+    const rootLocales = this.translationService.getLocaleInfo(i18nPath).allLocales
+    const mountLocales = readdirSync(absImportPath)
+      .filter(file => LOCALE_FILE.test(file))
+      .map(file => file.replace('.yaml', ''))
+
+    // Mount-only locales: delete the YAML file (no other artifact cleanup).
+    for (const locale of mountLocales)
+      if (!rootLocales.includes(locale))
+        unlinkSync(join(absImportPath, `${locale}.yaml`))
+
+    // Root-only locales: generate from the imported inputs.
+    const missing = rootLocales.filter(locale => !mountLocales.includes(locale))
+    if (missing.length > 0) {
+      const inputs = this.contextManager.getAllContextEntries(dir)
+      const entries = Object.entries(inputs).map(([key, entry]) => ({
+        key,
+        value: entry.input,
+        context: entry.context,
+      }))
+
+      // Enrichment comes from the root project, not the external mount.
+      const projectContext = this.translationService.getGlobalProjectContext(i18nPath)
+      const genderInstructions = this.translationService.getGenderInstructions(i18nPath)
+
+      for (const locale of missing) {
+        const data = await this.createCommand.translateEntries(entries, locale, projectContext, genderInstructions)
+        const yamlContent = yamlDump(data, { lineWidth: -1, quotingType: '"', forceQuotes: false })
+
+        writeFileSync(join(absImportPath, `${locale}.yaml`), yamlContent)
+      }
+    }
+
+    build(i18nPath)
+  }
+}

--- a/source/cli/cli.ts
+++ b/source/cli/cli.ts
@@ -21,6 +21,7 @@ import { DestroyCommand } from './DestroyCommand'
 import { SyncCommand } from './SyncCommand'
 import { HolaCommand } from './HolaCommand'
 import { MountCommand } from './MountCommand'
+import { ImportCommand } from './ImportCommand'
 import { UnmountCommand } from './UnmountCommand'
 import { ConstCommand } from './ConstCommand'
 import { ContextCommand } from './ContextCommand'
@@ -66,6 +67,25 @@ const cli = yargs(hideBin(process.argv))
   }, async (argv) => {
     const mountCommand = new MountCommand()
     await mountCommand.execute(argv.mount!, argv.dir!, argv.js, argv.path)
+  })
+  .command('import <name> <dir>', 'Adopt an existing dictionary directory as a mount and reconcile its locales', (yargs) => {
+    return yargs
+      .positional('name', {
+        describe: 'Mount name',
+        type: 'string'
+      })
+      .positional('dir', {
+        describe: 'Path to existing dictionary directory',
+        type: 'string'
+      })
+      .option('js', {
+        type: 'boolean',
+        default: false,
+        description: 'Use JavaScript instead of TypeScript'
+      })
+  }, async (argv) => {
+    const importCommand = new ImportCommand()
+    await importCommand.execute(argv.name!, argv.dir!, argv.js, argv.path)
   })
   .command('unmount <mount>', 'Remove a mount from context (keeps partition files)', (yargs) => {
     return yargs


### PR DESCRIPTION
Grafts a populated dictionary dir into the project as a mount, then
reconciles its locales to the root: drops mount-only locale files,
generates root-only ones by translating the imported context.yaml
inputs (root global context + genders applied), leaves the
intersection and imported context.yaml untouched. Reuses
CreateCommand translation pipeline via new translateEntries().